### PR TITLE
Replace deprecated method 'setting_getbool' with 'settings:get_bool'

### DIFF
--- a/creatures/functions.lua
+++ b/creatures/functions.lua
@@ -207,7 +207,7 @@ end
 
 local tool_uses = {0, 30, 110, 150, 280, 300, 500, 1000}
 local function addWearout(player, tool_def)
-	if not minetest.setting_getbool("creative_mode") then
+	if not minetest.settings:get_bool("creative_mode") then
 		local item = player:get_wielded_item()
 		if tool_def and tool_def.damage_groups and tool_def.damage_groups.fleshy then
 			local uses = tool_uses[tool_def.damage_groups.fleshy] or 0
@@ -222,7 +222,7 @@ end
 
 local function spawnParticles(...)
 end
-if minetest.setting_getbool("creatures_enable_particles") == true then
+if minetest.settings:get_bool("creatures_enable_particles") == true then
   spawnParticles = function(pos, velocity, texture_str)
     local vel = vector.multiply(velocity, 0.5)
     vel.y = 0

--- a/creatures/functions.lua
+++ b/creatures/functions.lua
@@ -207,7 +207,7 @@ end
 
 local tool_uses = {0, 30, 110, 150, 280, 300, 500, 1000}
 local function addWearout(player, tool_def)
-	if not core.setting_getbool("creative_mode") then
+	if not minetest.setting_getbool("creative_mode") then
 		local item = player:get_wielded_item()
 		if tool_def and tool_def.damage_groups and tool_def.damage_groups.fleshy then
 			local uses = tool_uses[tool_def.damage_groups.fleshy] or 0
@@ -222,7 +222,7 @@ end
 
 local function spawnParticles(...)
 end
-if core.setting_getbool("creatures_enable_particles") == true then
+if minetest.setting_getbool("creatures_enable_particles") == true then
   spawnParticles = function(pos, velocity, texture_str)
     local vel = vector.multiply(velocity, 0.5)
     vel.y = 0

--- a/creatures/register.lua
+++ b/creatures/register.lua
@@ -20,7 +20,7 @@
 --
 
 
-local allow_hostile = minetest.setting_getbool("only_peaceful_mobs") ~= true
+local allow_hostile = minetest.settings:get_bool("only_peaceful_mobs") ~= true
 
 local function translate_def(def)
   local new_def = {
@@ -179,7 +179,7 @@ local function translate_def(def)
 
     self.object:set_hp(self.hp)
 
-    if not minetest.setting_getbool("enable_damage") then
+    if not minetest.settings:get_bool("enable_damage") then
       self.hostile = false
     end
 
@@ -412,7 +412,7 @@ local function eggSpawn(itemstack, placer, pointed_thing, egg_def)
     local height = (egg_def.box[5] or 2) - (egg_def.box[2] or 0)
     if checkSpace(pos, height) == true then
       core.add_entity(pos, egg_def.mob_name)
-      if minetest.setting_getbool("creative_mode") ~= true then
+      if minetest.settings:get_bool("creative_mode") ~= true then
         itemstack:take_item()
       end
     end

--- a/creatures/register.lua
+++ b/creatures/register.lua
@@ -20,7 +20,7 @@
 --
 
 
-local allow_hostile = core.setting_getbool("only_peaceful_mobs") ~= true
+local allow_hostile = minetest.setting_getbool("only_peaceful_mobs") ~= true
 
 local function translate_def(def)
   local new_def = {
@@ -179,7 +179,7 @@ local function translate_def(def)
 
     self.object:set_hp(self.hp)
 
-    if not core.setting_getbool("enable_damage") then
+    if not minetest.setting_getbool("enable_damage") then
       self.hostile = false
     end
 
@@ -412,7 +412,7 @@ local function eggSpawn(itemstack, placer, pointed_thing, egg_def)
     local height = (egg_def.box[5] or 2) - (egg_def.box[2] or 0)
     if checkSpace(pos, height) == true then
       core.add_entity(pos, egg_def.mob_name)
-      if core.setting_getbool("creative_mode") ~= true then
+      if minetest.setting_getbool("creative_mode") ~= true then
         itemstack:take_item()
       end
     end

--- a/sheep/init.lua
+++ b/sheep/init.lua
@@ -189,7 +189,7 @@ local def = {
 					shear(self, math.random(2, 3), true)
 					item:add_wear(65535/100)
 				end
-				if not minetest.setting_getbool("creative_mode") then
+				if not minetest.settings:get_bool("creative_mode") then
 					clicker:set_wielded_item(item)
 				end
 			end

--- a/sheep/init.lua
+++ b/sheep/init.lua
@@ -189,7 +189,7 @@ local def = {
 					shear(self, math.random(2, 3), true)
 					item:add_wear(65535/100)
 				end
-				if not core.setting_getbool("creative_mode") then
+				if not minetest.setting_getbool("creative_mode") then
 					clicker:set_wielded_item(item)
 				end
 			end


### PR DESCRIPTION
May not want to merge this until after 0.4.16 release, as the new ['settings' object calls][l_settings] are not available in 0.4.15.

[l_settings]: https://github.com/minetest/minetest/blob/43d1f375d18a2fbc547a9b4f23d1354d645856ca/src/script/lua_api/l_settings.cpp#L267